### PR TITLE
remove the include for WiFiClient.h

### DIFF
--- a/ESP-sc-gway/ESP-sc-gway.ino
+++ b/ESP-sc-gway/ESP-sc-gway.ino
@@ -76,7 +76,6 @@ extern "C" {
 #if ESP32_ARCH==1								// IF ESP32
 
 #include "WiFi.h"
-#include <WiFIClient.h>
 #include <ESPmDNS.h>
 #include <SPIFFS.h>
 #if A_SERVER==1


### PR DESCRIPTION
it is already included/available via WiFi.h and results in compiler errors if
included again.