### PR TITLE
Fix Downlink Bandwidth Plan Frequency 915

### DIFF
--- a/ESP-sc-gway/_loraModem.ino
+++ b/ESP-sc-gway/_loraModem.ino
@@ -178,7 +178,7 @@ void writeBuffer(uint8_t addr, uint8_t *buf, uint8_t len)
 //		CRC_ON == 0x04
 // ----------------------------------------------------------------------------
 
-void setRate(uint8_t sf, uint8_t crc) 
+void setRate(uint8_t sf, uint8_t crc, bool bw500_4_5 = false) 
 {
 	uint8_t mc1=0, mc2=0, mc3=0;
 #if DUSB>=2
@@ -190,6 +190,7 @@ void setRate(uint8_t sf, uint8_t crc)
 		return;
 	}
 #endif
+
 	// Set rate based on Spreading Factor etc
     if (sx1272) {
 		mc1= 0x0A;				// SX1276_MC1_BW_250 0x80 | SX1276_MC1_CR_4_5 0x02
@@ -206,9 +207,14 @@ void setRate(uint8_t sf, uint8_t crc)
 		else {
 			mc1= 0x72;				// SX1276_MC1_BW_125==0x70 | SX1276_MC1_CR_4_5==0x02
 		}
+
+		if (bw500_4_5) {
+      		mc1 = 0x92;
+    	}
+
 		mc2= ((sf<<4) | crc) & 0xFF; // crc is 0x00 or 0x04==SX1276_MC2_RX_PAYLOAD_CRCON
 		mc3= 0x04;				// 0x04; SX1276_MC3_AGCAUTO
-        if (sf == SF11 || sf == SF12) { mc3|= 0x08; }		// 0x08 | 0x04
+        if ((sf == SF11 || sf == SF12) && (bw500_4_5 == false) ) { mc3|= 0x08; }		// 0x08 | 0x04
     }
 	
 	// Implicit Header (IH), for class b beacons (&& SF6)
@@ -695,7 +701,12 @@ void txLoraModem(uint8_t *payLoad, uint8_t payLength, uint32_t tmst, uint8_t sfT
 	}
 #endif
 	_state = S_TX;
-		
+
+	bool bw500_4_5 = true;	
+#if _STRICT_1CH
+  bw500_4_5 = false;
+#endif
+
 	// 1. Select LoRa modem from sleep mode
 	//opmode(OPMODE_LORA);									// set register 0x01 to 0x80
 	
@@ -706,7 +717,7 @@ void txLoraModem(uint8_t *payLoad, uint8_t payLength, uint32_t tmst, uint8_t sfT
 	opmode(OPMODE_STANDBY);									// set 0x01 to 0x01
 	
 	// 3. Init spreading factor and other Modem setting
-	setRate(sfTx, crc);
+	setRate(sfTx, crc, bw500_4_5);
 	
 	// Frquency hopping
 	//writeRegister(REG_HOP_PERIOD, (uint8_t) 0x00);		// set 0x24 to 0x00 only for receivers

--- a/ESP-sc-gway/_loraModem.ino
+++ b/ESP-sc-gway/_loraModem.ino
@@ -702,9 +702,12 @@ void txLoraModem(uint8_t *payLoad, uint8_t payLength, uint32_t tmst, uint8_t sfT
 #endif
 	_state = S_TX;
 
-	bool bw500_4_5 = true;	
+	bool bw500_4_5 = false;	
+
 #if _STRICT_1CH
   bw500_4_5 = false;
+#elif _LFREQ==915
+  bw500_4_5 = true;
 #endif
 
 	// 1. Select LoRa modem from sleep mode

--- a/ESP-sc-gway/_txRx.ino
+++ b/ESP-sc-gway/_txRx.ino
@@ -466,8 +466,7 @@ int buildPacket(uint32_t tmst, uint8_t *buff_up, struct LoraUp LoraUp, bool inte
 	}
 #endif
 	buff_index += j;
-	ftoa((double)freq/1000000,cfreq,6);					// XXX This can be done better
-	j = snprintf((char *)(buff_up + buff_index), TX_BUFF_SIZE-buff_index, ",\"chan\":%1u,\"rfch\":%1u,\"freq\":%s", 0, 0, cfreq);
+	j = snprintf((char *)(buff_up + buff_index), TX_BUFF_SIZE-buff_index, ",\"chan\":%1u,\"rfch\":%1u,\"freq\":%.2f", 0, 0, freq / 1000000.0);
 	buff_index += j;
 	memcpy((void *)(buff_up + buff_index), (void *)",\"stat\":1", 9);
 	buff_index += 9;

--- a/ESP-sc-gway/_wwwServer.ino
+++ b/ESP-sc-gway/_wwwServer.ino
@@ -431,6 +431,9 @@ static void settingsData()
 	}
 	else {
 		response += String() + ifreq; 
+		response += " [ "; 
+		response += String() + freqs[ifreq]; 
+		response += " ]"; 
 		response +="</td>";
 		response +="<td class=\"cell\"><a href=\"FREQ=-1\"><button>-</button></a></td>";
 		response +="<td class=\"cell\"><a href=\"FREQ=1\"><button>+</button></a></td>";

--- a/ESP-sc-gway/loraModem.h
+++ b/ESP-sc-gway/loraModem.h
@@ -148,16 +148,28 @@ unsigned long detTime=0;
 // ----------------------------------------------------------------------------
 // Definition of the GPIO pins used by the Gateway for Hallard type boards
 //
-struct pins {
-	uint8_t dio0=15;	// GPIO15 / D8. For the Hallard board shared between DIO0/DIO1/DIO2
-	uint8_t dio1=15;	// GPIO15 / D8. Used for CAD, may or not be shared with DIO0
-	uint8_t dio2=15;	// GPIO15 / D8. Used for frequency hopping, don't care
-	uint8_t ss=16;		// GPIO16 / D0. Select pin connected to GPIO16 / D0
-	uint8_t rst=0;		// GPIO 0 / D3. Reset pin not used	
-	// MISO 12 / D6
-	// MOSI 13 / D7
-	// CLK  14 / D5
-} pins;
+
+// For MH-ET ESP32 MiniKit 
+#if defined (ARDUINO_ARCH_ESP32) || defined(ESP32)
+  struct pins {
+  	uint8_t dio0=5;	// GPIO5
+  	uint8_t dio1=5;	// GPIO5
+  	uint8_t dio2=5;	// GPIO5
+  	uint8_t ss=26;		// GPIO26
+  	uint8_t rst=0;		// Reset pin not used	
+  } pins;
+#else
+  struct pins {
+    uint8_t dio0=15; // GPIO15 / D8. For the Hallard board shared between DIO0/DIO1/DIO2
+    uint8_t dio1=15; // GPIO15 / D8. Used for CAD, may or not be shared with DIO0
+    uint8_t dio2=15; // GPIO15 / D8. Used for frequency hopping, don't care
+    uint8_t ss=16;    // GPIO16 / D0. Select pin connected to GPIO16 / D0
+    uint8_t rst=0;    // GPIO 0 / D3. Reset pin not used  
+    // MISO 12 / D6
+    // MOSI 13 / D7
+    // CLK  14 / D5
+  } pins;
+#endif
 
 #elif _PIN_OUT==2
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Hello,

Based on [https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html](https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html) 

The Bandwidth from most Frequency 915 is BW500, so I make some shenanigans to fix.
I just force downlink to change to BW500 when the frequency is 915, but I guess the right way is to create a `LoraDown.bwTx ` and check the package `datr`.

👍 


