### PR TITLE
Added support for Heltec ESP32 LoRa V2 boards

### DIFF
--- a/ESP-sc-gway/ESP-sc-gway.h
+++ b/ESP-sc-gway/ESP-sc-gway.h
@@ -84,9 +84,10 @@
 //	1: HALLARD
 //	2: COMRESULT pin out
 //	3: ESP32 Wemos pin out
-//	4: ESP32 TTGO pinning (should work for 433 and OLED too).
+//	4: ESP32 TTGO (including Heltec V1) pinning (should work for 433 and OLED too).
 //	5: ESP32 TTGO EU433 MHz with OLED
-//	6: Other, define your own in loraModem.h
+//	6: ESP32 Heltec V2 board (different Pinning than Heltec V1)
+//	7: Other, define your own in loraModem.h
 #define _PIN_OUT 1
 
 // Gather statistics on sensor and Wifi status

--- a/ESP-sc-gway/loraModem.h
+++ b/ESP-sc-gway/loraModem.h
@@ -182,7 +182,7 @@ struct pins {
 struct pins {
 	uint8_t dio0=26;		// GPIO26 / Dio0 used for one frequency and one SF
 	uint8_t dio1=26;		// GPIO26 / Used for CAD, may or not be shared with DIO0
-	uint8_t dio2=26;		// GPI2O6 / Used for frequency hopping, don't care
+	uint8_t dio2=26;		// GPIO26 / Used for frequency hopping, don't care
 	uint8_t ss=18;			// GPIO18 / Dx. Select pin connected to GPIO18
 	uint8_t rst=14;			// GPIO0  / D3. Reset pin not used	
 } pins;
@@ -190,7 +190,7 @@ struct pins {
 
 #elif _PIN_OUT==4
 // ----------------------------------------------------------------------------
-// For ESP32/TTGO based board.
+// For ESP32/TTGO based (including Heltec V1) board.
 // SCK  == GPIO5/ PIN5
 // SS   == GPIO18/PIN18 CS
 // MISO == GPIO19/ PIN19
@@ -198,8 +198,8 @@ struct pins {
 // RST  == GPIO14/ PIN14
 struct pins {
 	uint8_t dio0=26;		// GPIO26 / Dio0 used for one frequency and one SF
-	uint8_t dio1=33;		// GPIO26 / Used for CAD, may or not be shared with DIO0
-	uint8_t dio2=32;		// GPIO26 / Used for frequency hopping, don't care
+	uint8_t dio1=33;		// GPIO33 / Used for CAD, may or not be shared with DIO0
+	uint8_t dio2=32;		// GPIO32 / Used for frequency hopping, don't care
 	uint8_t ss=18;			// GPIO18 / Dx. Select pin connected to GPIO18
 	uint8_t rst=14;			// GPIO0  / D3. Reset pin not used	
 } pins;
@@ -224,8 +224,8 @@ struct pins {
 // RST  == GPIO14/ PIN14
 struct pins {
 	uint8_t dio0=26;		// GPIO26 / Dio0 used for one frequency and one SF
-	uint8_t dio1=33;		// GPIO26 / Used for CAD, may or not be shared with DIO0
-	uint8_t dio2=32;		// GPIO26 / Used for frequency hopping, don't care
+	uint8_t dio1=33;		// GPIO33 / Used for CAD, may or not be shared with DIO0
+	uint8_t dio2=32;		// GPIO32 / Used for frequency hopping, don't care
 	uint8_t ss=18;			// GPIO18 / Dx. Select pin connected to GPIO18
 	uint8_t rst=14;			// GPIO0 / D3. Reset pin not used	
 } pins;
@@ -233,6 +233,27 @@ struct pins {
 #define MISO 19				// Check
 #define MOSI 27				// Check
 #define RST 14				// Check
+#define SS 18
+
+#elif _PIN_OUT==6
+// ----------------------------------------------------------------------------
+// For ESP32 Heltec V2 board (different Pinning than Heltec V1).
+// SCK  == GPIO5/ PIN5
+// SS   == GPIO18/PIN18 CS
+// MISO == GPIO19/ PIN19
+// MOSI == GPIO27/ PIN27
+// RST  == GPIO14/ PIN14
+struct pins {
+	uint8_t dio0=26;		// GPIO26 / Dio0 used for one frequency and one SF
+	uint8_t dio1=35;		// GPIO35 / Used for CAD, may or not be shared with DIO0
+	uint8_t dio2=34;		// GPIO34 / Used for frequency hopping, don't care
+	uint8_t ss=18;			// GPIO18 / Dx. Select pin connected to GPIO18
+	uint8_t rst=14;			// GPIO0  / D3. Reset pin not used	
+} pins;
+#define SCK 5
+#define MISO 19
+#define MOSI 27
+#define RST 14
 #define SS 18
 
 #else

--- a/ESP-sc-gway/oLED.h
+++ b/ESP-sc-gway/oLED.h
@@ -41,7 +41,7 @@
 #define OLED_SCL 0								// GPIO0 / D3
 #define OLED_SDA 2								// GPIO2 / D4
 
-#elif _PIN_OUT==4								// TTGO (onboard version used, also for DIY)
+#elif _PIN_OUT==4 || _PIN_OUT==6				// TTGO (onboard version used, also for DIY)
 #define OLED_SCL 15								// GPIO15 / 
 #define OLED_SDA 4								// GPIO4 / 
 #define OLED_RST 16								// Reset pin (Some OLED displays do not have it)


### PR DESCRIPTION
As i had problems, getting the code to work with my new Heltec **V2** ESP32 LoRa boards, i extended the PINOUT options by a new PINOUT for this specific board.